### PR TITLE
Ignore functional components on default props

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -29,7 +29,7 @@ module.exports = {
         "react/no-unescaped-entities": "warn",
         "react/no-unused-prop-types": "warn",
         "react/no-unused-state": "warn",
-        "react/require-default-props": "warn",
+        "react/require-default-props": ["warn", { "ignoreFunctionalComponents": true }],
         "react/self-closing-comp": "warn",
         "react/sort-comp": 0,
         "react/style-prop-object": "warn",


### PR DESCRIPTION
Default Props are a pattern we are moving away from. (Let typescript do it's job).

Start by removing the warning for functional components cause that's what most of our new development is in.