### PR TITLE
changeset version before changeset publish

### DIFF
--- a/.changeset/early-spoons-itch.md
+++ b/.changeset/early-spoons-itch.md
@@ -1,0 +1,5 @@
+---
+'@ordermentum/eslint-config-ordermentum': patch
+---
+
+Updated changeset command to version before publishing

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "John D'Agostino <john@ordermentum.com>",
   "license": "MIT",
   "scripts": {
-    "release": "changeset publish"
+    "release": "changeset version && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
The changeset version needs to happen before we publish otherwise the number does not increment