### PR TITLE
Fix rule name 

### DIFF
--- a/.changeset/fair-hats-allow.md
+++ b/.changeset/fair-hats-allow.md
@@ -1,0 +1,5 @@
+---
+'@ordermentum/eslint-config-ordermentum': patch
+---
+
+Correct rule name declaration '@typescript-eslint/no-unnecessary-condition'

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
     'no-template-curly-in-string': 'warn',
     'no-undef': 'error',
     'no-useless-escape': 'warn',
-    'typescript-eslint/no-unnecessary-condition': 'warn',
+    '@typescript-eslint/no-unnecessary-condition': 'warn',
     'no-useless-return': 'warn',
     'space-before-function-paren': 'off',
     'no-await-in-loop': 'off',


### PR DESCRIPTION
#### Description

[SUPPLIER-2962](https://ordermentum.atlassian.net/browse/SUPPLIER-2962)

Missing `@` is resulting in errors when running the linter in projects

```
/Users/pedro/Documents/ui/apps/admin/test/utility/parseUtils_test.js
  1:1  error  Definition for rule 'typescript-eslint/no-unnecessary-condition' was not found  typescript-eslint/no-unnecessary-condition

/Users/pedro/Documents/ui/apps/admin/utility/parseUtils.js
  1:1  error  Definition for rule 'typescript-eslint/no-unnecessary-condition' was not found  typescript-eslint/no-unnecessary-condition
```

----
#### PR Type

_Check one or more and add the corresponding number of reviewers_

- [x] Bugfix or minor change _(1)_
- [ ] Feature _(2)_
- [ ] Breaking change (existing functionality no longer works as expected) _(2)_
- [ ] Critical impact (security, payments or critical functionality) _(2+CTO)_

----
#### Changes

_List the main changes in this PR. Include screenshots if necessary._

----

#### Acceptance Criteria

_How can we test that this meets the requirements of the ticket?_

----

#### Checklist:

- [ ] Tests – Have you added or edited the test cases?
- [ ] Context – Have you tested this with a non-admin user?
- [ ] Rebase – Has this PR been rebased against `develop`?
- [ ] Feature Flag - If this is a new feature, does it have a feature flag?
- [ ] Release - Can this be released to production once tested?
