### PR TITLE
Disable prop types checks in ts files

### DIFF
--- a/.changeset/polite-terms-glow.md
+++ b/.changeset/polite-terms-glow.md
@@ -1,0 +1,5 @@
+---
+'@ordermentum/eslint-config-ordermentum': minor
+---
+
+Disable prop-types checks in typescript files

--- a/browser.js
+++ b/browser.js
@@ -91,6 +91,13 @@ module.exports = {
         'no-undef': 'off',
         'import/prefer-default-export': 'off',
         'import/order': 'warn',
+        // we do not use prop-types in typescript files
+        'react/prop-types': 'off',
+        'react/require-default-props': 'off',
+        'react/default-props-match-prop-types': 'off',
+        'react/forbid-prop-type': 'off',
+        'react/forbid-prop-types': 'off',
+        'react/no-unused-prop-types': 'off',
       },
       settings: {
         'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],


### PR DESCRIPTION
#### Description

What the title says. We are currently seeing these warnings,

<img width="1022" alt="Screenshot 2024-09-05 at 9 38 51 AM" src="https://github.com/user-attachments/assets/7296d598-60c2-4fa5-b517-4ac63de38c6e">

`prop-types` are only used in javascript files (that have yet to be ported to typescript) so having these checks in typescript files do not add any value (just noise)

This is an issue as we have a pre-commit hook that will fail on warnings.

----
#### PR Type

_Check one or more and add the corresponding number of reviewers_

- [ ] Bugfix or minor change _(1)_
- [ ] Feature _(2)_
- [ ] Breaking change (existing functionality no longer works as expected) _(2)_
- [ ] Critical impact (security, payments or critical functionality) _(2+CTO)_

----
#### Changes

_List the main changes in this PR. Include screenshots if necessary._

----

#### Acceptance Criteria

_How can we test that this meets the requirements of the ticket?_

----

#### Checklist:

- [ ] Tests – Have you added or edited the test cases?
- [ ] Context – Have you tested this with a non-admin user?
- [ ] Rebase – Has this PR been rebased against `develop`?
- [ ] Feature Flag - If this is a new feature, does it have a feature flag?
- [ ] Release - Can this be released to production once tested?
